### PR TITLE
Feat: Add a new column for installation table of dashboard tab

### DIFF
--- a/src/components/table/warehouse_dashboard/InstallationStatusTable.vue
+++ b/src/components/table/warehouse_dashboard/InstallationStatusTable.vue
@@ -129,6 +129,11 @@
               <div style="padding: 10px">
                 <el-table :data="getPaginatedItemsInDialog(partNoRow)" border size="small">
                   <el-table-column
+                    prop="cabinet_no"
+                    label="MD"
+                    width="auto"
+                  />
+                  <el-table-column
                     prop="higher_lever_function"
                     :label="langStore.t('tableHigherLeverFunction')"
                     width="auto"


### PR DESCRIPTION
- Add a new column for installation table of dashboard tab
<img width="1922" height="1007" alt="image" src="https://github.com/user-attachments/assets/e5175d22-87c2-4abc-8dda-0e5163c51c60" />
